### PR TITLE
Add get_node_name function to API

### DIFF
--- a/doc/lua_api.txt
+++ b/doc/lua_api.txt
@@ -2426,6 +2426,10 @@ and `minetest.auth_reload` call the authetification handler.
     * `pos`: The position where to measure the light.
     * `timeofday`: `nil` for current time, `0` for night, `0.5` for day
     * Returns a number between `0` and `15` or `nil`
+* `minetest.get_node_name(pos)`
+    * Returns the node name at the given position as string
+        returns "ignore" for unloaded areas
+    * Is the same as minetest.get_node(pos).name but more faster
 * `minetest.place_node(pos, node)`
     * Place node with the same effects that a player would cause
 * `minetest.dig_node(pos)`

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -264,6 +264,22 @@ int ModApiEnvMod::l_get_node_light(lua_State *L)
 	return 1;
 }
 
+// get_node_name(pos)
+// pos = {x=num, y=num, z=num}
+int ModApiEnvMod::l_get_node_name(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	// pos
+	v3s16 pos = read_v3s16(L, 1);
+	// Do it
+	MapNode n = env->getMap().getNodeNoEx(pos);
+	INodeDefManager *ndef = env->getGameDef()->ndef();
+	// Return node name string
+	lua_pushstring(L, ndef->get(n).name.c_str());
+	return 1;
+}
+
 // place_node(pos, node)
 // pos = {x=num, y=num, z=num}
 int ModApiEnvMod::l_place_node(lua_State *L)
@@ -1099,6 +1115,7 @@ void ModApiEnvMod::Initialize(lua_State *L, int top)
 	API_FCT(get_node);
 	API_FCT(get_node_or_nil);
 	API_FCT(get_node_light);
+	API_FCT(get_node_name);
 	API_FCT(place_node);
 	API_FCT(dig_node);
 	API_FCT(punch_node);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -52,6 +52,10 @@ private:
 	// timeofday: nil = current time, 0 = night, 0.5 = day
 	static int l_get_node_light(lua_State *L);
 
+	// get_node_name(pos)
+	// pos = {x=num, y=num, z=num}
+	static int l_get_node_name(lua_State *L);
+
 	// place_node(pos, node)
 	// pos = {x=num, y=num, z=num}
 	static int l_place_node(lua_State *L);


### PR DESCRIPTION
Add function minetest.get_node_name(pos) to API more fast than minetest.get_node(pos).name