### PR TITLE
Fix for translating empty strings

### DIFF
--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -152,7 +152,10 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect < s32 > rect(0, 0, 100, 30);
 			rect += topleft + v2s32(offset.X + 120, offset.Y - 5);
-			const wchar_t *text = wgettext(k->key.name());
+			/* Whe must check here for an empty string, "" is reserved 
+			 * for gettext to return the header of the .po file
+			 */
+			const wchar_t *text = k->key.name()[0] ? wgettext(k->key.name()) : *L"";
 			k->button = Environment->addButton(rect, this, k->id, text);
 			delete[] text;
 		}


### PR DESCRIPTION
Fix for incorrect translation of empty strings

In the key change menu, when a button key not heve name an empty string is passed to gettext.
The empty string is reserved for gettext to return de header of the .po file an this is shoved in the button

![minetest](https://user-images.githubusercontent.com/30205587/37868730-365b9576-2fa3-11e8-8c76-6a6a7df80278.png)

Thanks HybridDog for find the origin of those text