### PR TITLE
Fix for incorrect translation of empty strings

### DIFF
--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -152,7 +152,9 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect < s32 > rect(0, 0, 100, 30);
 			rect += topleft + v2s32(offset.X + 120, offset.Y - 5);
-			const wchar_t *text = k->key.name()[0] ? wgettext(k->key.name()) : *L"";
+			const wchar_t *text = *L"";
+			if (k->key.name()[0])
+				text = wgettext(k->key.name());
 			k->button = Environment->addButton(rect, this, k->id, text);
 			delete[] text;
 		}

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -152,11 +152,12 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect < s32 > rect(0, 0, 100, 30);
 			rect += topleft + v2s32(offset.X + 120, offset.Y - 5);
-			const wchar_t *text = *L"";
-			if (k->key.name()[0])
-				text = wgettext(k->key.name());
-			k->button = Environment->addButton(rect, this, k->id, text);
-			delete[] text;
+			if (k->key.name()[0]) {
+				const wchar_t *text = wgettext(k->key.name());
+				k->button = Environment->addButton(rect, this, k->id, text);
+				delete[] text;
+			} else
+				k->button = Environment->addButton(rect, this, k->id, L"");
 		}
 		if ((i + 1) % KMaxButtonPerColumns == 0) {
 			offset.X += 230;

--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -152,7 +152,7 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect < s32 > rect(0, 0, 100, 30);
 			rect += topleft + v2s32(offset.X + 120, offset.Y - 5);
-			const wchar_t *text = wgettext(k->key.name());
+			const wchar_t *text = k->key.name()[0] ? wgettext(k->key.name()) : *L"";
 			k->button = Environment->addButton(rect, this, k->id, text);
 			delete[] text;
 		}


### PR DESCRIPTION
In the key change menu, when a button key not have name an empty string is passed to gettext.
The empty string is reserved for gettext to return de header of the .po file an this is shoved in the button

file:///home/guadalinex/Descargas/minetest.png