### PR TITLE
Key change menu: Fix for translating empty string

### DIFF
--- a/src/guiKeyChangeMenu.cpp
+++ b/src/guiKeyChangeMenu.cpp
@@ -152,7 +152,8 @@ void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
 		{
 			core::rect < s32 > rect(0, 0, 100, 30);
 			rect += topleft + v2s32(offset.X + 120, offset.Y - 5);
-			const wchar_t *text = wgettext(k->key.name());
+			// We have to check here that it is not an empty string to avoid trying to translate it
+			const wchar_t *text = k->key.name()[0] ? wgettext(k->key.name()) : utf8_to_wide_c("");
 			k->button = Environment->addButton(rect, this, k->id, text);
 			delete[] text;
 		}


### PR DESCRIPTION
Fix for incorrect translation of empty strings in key change menu

In the key change menu, when a button key not have name an empty string is passed to gettext.
The empty string is reserved for gettext to return de header of the .po file an this is shoved in the button

![minetest](https://user-images.githubusercontent.com/30205587/38053963-0aadb498-32c5-11e8-8d3f-378c7ed7ddbb.png)

Thank you HybridDog for finding the source of that text, I've seen it for months without knowing where it might be.